### PR TITLE
Make proximity chat work with Safari

### DIFF
--- a/auproximity-webui/src/components/ServerDisplayer.vue
+++ b/auproximity-webui/src/components/ServerDisplayer.vue
@@ -37,6 +37,9 @@ import MyClientListItem from '@/components/MyClientListItem.vue'
 import HostOptions from '@/components/HostOptions.vue'
 import { GameSettings } from '@/models/RoomModel'
 
+const AudioContext = window.AudioContext || // Default
+  (window as any).webkitAudioContext // Safari and old versions of Chrome
+
 @Component({
   components: { MyClientListItem, ClientListItem, HostOptions },
   directives: {


### PR DESCRIPTION
This change will let people use the chat on their iphone / ipad (in
addition to Safari on a Mac).

Safari uses a prefixed AudioContext. See https://stackoverflow.com/questions/29373563/audiocontext-on-safari

I don't know anything about Vue apps, so please let me know if there's
a better way to make this change.

To test I deployed to Heroku and was able to chat between Chrome and Safari on iPad, and between Chrome and Safari on the Mac.